### PR TITLE
Use default query timeout from image parameters

### DIFF
--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -58,9 +58,7 @@ class ConfigDefinition extends BaseConfigDefinition
         $parametersNode
             ->isRequired()
             ->children()
-                ->integerNode('query_timeout')
-                    ->defaultValue(7200)
-                ->end()
+                ->integerNode('query_timeout')->defaultValue(null)->end()
                 ->arrayNode('blocks')
                     ->isRequired()
                     ->prototype('array')

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -87,6 +87,47 @@ class ConfigTest extends TestCase
         Assert::assertSame(7200, $config->getQueryTimeout());
     }
 
+    public function testQueryTimeoutFromImageParameters(): void
+    {
+        $config = new Config([
+            'authorization' => $this->getAuthorizationNode(),
+            'parameters' => [
+                'blocks' => [
+                    [
+                        'name' => 'Block 1',
+                        'codes' => [],
+                    ],
+                ],
+            ],
+            'image_parameters' => [
+                'default_query_timeout' => 123000,
+            ],
+        ], new ConfigDefinition());
+
+        Assert::assertSame(123000, $config->getQueryTimeout());
+    }
+
+    public function testQueryTimeoutFromConfigParameters(): void
+    {
+        $config = new Config([
+            'authorization' => $this->getAuthorizationNode(),
+            'parameters' => [
+                'query_timeout' => 456000,
+                'blocks' => [
+                    [
+                        'name' => 'Block 1',
+                        'codes' => [],
+                    ],
+                ],
+            ],
+            'image_parameters' => [
+                'default_query_timeout' => 123000,
+            ],
+        ], new ConfigDefinition());
+
+        Assert::assertSame(456000, $config->getQueryTimeout());
+    }
+
     /**
      * @dataProvider validConfigProvider
      */


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-560

Changes:
- Query timeout is loaded from the: 1. `image_parameters` 2. `parameters` 3. default value `7200` (2h)